### PR TITLE
add python2-psutil dep to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For all versions :
 GTK2 frontend
  - python2
  - pygtk
+ - python2-psutil
 
 GTK3 frontend
  - python3


### PR DESCRIPTION
on parabola (archlinux derivative) i found that the program would not launch without the 'python2-psutil' package - i did not try building with python3 or agaist GTK3 so i added this dependency only to the GTK2 section
